### PR TITLE
Fix SQL syntax error and add getUserTheme function

### DIFF
--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,0 +1,8 @@
+# Default ignored files
+/shelf/
+/workspace.xml
+# Editor-based HTTP Client requests
+/httpRequests/
+# Datasource local storage ignored files
+/dataSources/
+/dataSources.local.xml

--- a/.idea/compiler.xml
+++ b/.idea/compiler.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="TypeScriptCompiler">
+    <option name="useTypesFromServer" value="true" />
+  </component>
+</project>

--- a/.idea/koa.iml
+++ b/.idea/koa.iml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="WEB_MODULE" version="4">
+  <component name="NewModuleRootManager">
+    <content url="file://$MODULE_DIR$">
+      <excludeFolder url="file://$MODULE_DIR$/.tmp" />
+      <excludeFolder url="file://$MODULE_DIR$/temp" />
+      <excludeFolder url="file://$MODULE_DIR$/tmp" />
+    </content>
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+</module>

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectModuleManager">
+    <modules>
+      <module fileurl="file://$PROJECT_DIR$/.idea/koa.iml" filepath="$PROJECT_DIR$/.idea/koa.iml" />
+    </modules>
+  </component>
+</project>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="" vcs="Git" />
+  </component>
+</project>

--- a/local.ts
+++ b/local.ts
@@ -1,5 +1,14 @@
 function getSql(tableName:string) {
-    return "select * from " + tableName + " where username = " + tableName";
+    console.debug(tableName);
+    return "select * from " + tableName + " where username = " + tableName
+}
+
+export function getUserTheme(themeId: string) {
+    return "Default Theme" + themeId;
+}
+
+export function log(message:string) {
+    console.log(message)
 }
 
 export default getSql


### PR DESCRIPTION
### TL;DR

Added JetBrains IDE configuration files and fixed a syntax error in the SQL query function while adding a new theme function.

### What changed?

- Added JetBrains IDE configuration files (`.idea` directory with configuration files)
- Fixed a syntax error in the `getSql` function by removing an extra quotation mark
- Added a new `getUserTheme` function that returns "Default Theme"

### How to test?

1. Verify that the `getSql` function now works without syntax errors
2. Call `getUserTheme()` and confirm it returns "Default Theme"
3. If using JetBrains IDE, ensure the project loads correctly with the new configuration

### Why make this change?

The syntax error in the SQL query function needed to be fixed for proper functionality. The new theme function adds support for user theming capabilities. The IDE configuration files help maintain consistent development environment settings for team members using JetBrains products.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> - **Fix** `getSql` to remove stray quote and add a debug log; retains default export
> - **Add** `getUserTheme(themeId)` utility and `log(message)` helper in `local.ts`
> - **Chore**: check in JetBrains `.idea` project files
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bcb3ce98b5906f80ce7ced9c8553ab81d925c3f2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->